### PR TITLE
docs: add getting started documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ cd src/k-eval
 uv run python -m cli.main /path/to/config.yaml
 ```
 
-#### CLI Usage
+See [docs/run-configuration.md](docs/run-configuration.md) for authentication setup and all CLI options.
+
+#### CLI Options
 
 ```bash
 src/k-eval$ uv run python -m cli.main --help
@@ -152,4 +154,5 @@ execution:
   max_concurrent: 5
 ```
 
+See [docs/run-configuration.md](docs/run-configuration.md) for the full reference including authentication setup.
 

--- a/docs/evaluation-methodology.md
+++ b/docs/evaluation-methodology.md
@@ -55,9 +55,9 @@ A **condition** is a named experimental configuration specifying which MCP serve
 are available to the agent, and what system prompt is used.
 
 A **run** is the full evaluation of every sample under every condition. For example, a run with
-50 samples and 3 conditions would consist of 150 evaluations. With the default per-sample sampling
-of `N=3` (see [variance management techniques](#variance-management-techniques)), this would result
-in 450 total agent calls and 450 LLM judge calls. (Note that sampled scores are reported as 
+50 samples and 3 conditions would consist of 150 evaluations. With `num_repetitions: 3`
+(see [variance management techniques](#variance-management-techniques)), this would result
+in 450 total agent calls and 450 LLM judge calls. (Note that sampled scores are reported as
 average score & standard deviation. So the final reported scores would be the aggregate of 150 scores.)
 
 Conditions are explicitly defined by the user. `k-eval` does not automatically enumerate combinations.
@@ -279,7 +279,7 @@ sampling. A run configuration file can specify the number of
 responses that should be independently generated for a given
 question in the golden dataset. 
 
-By default, each response is sampled three times to balance
+By default, `num_repetitions` is set to 3 to balance
 statistical confidence with inference cost.
 
 These responses are then independently scored by the LLM judge.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,10 @@ The agent will be provided with 0 or more MCP servers that it can use to fetch c
 to answering the question(s). `k-eval` assesses the agent's performance with/without access to additional context,
 enabling measuring the direct impact of a MCP-based context provider on agent performance.
 
+## Getting Started
+
+See the [Quick Start](../README.md#quick-start) in the README.
+
 ## Evaluation Methodology
 
 Please reference [evaluation methodology](./evaluation-methodology.md)

--- a/docs/run-configuration.md
+++ b/docs/run-configuration.md
@@ -19,7 +19,7 @@ a rerun:
 ```yaml
 # A short name for this evaluation run. Used in output file names.
 name: "k-eval-demo"
-# Treat this as a schema version for your own config files — increment it
+# Treat this as a schema version for your own config files. Increment it
 # when you make meaningful changes so you can tell configs apart later.
 version: "1"
 
@@ -83,7 +83,7 @@ execution:
   # How many times each (question, condition) pair is evaluated. The mean and
   # standard deviation across repetitions are reported. Use 3 as a minimum;
   # 5+ gives more reliable variance estimates.
-  num_repetitions: 5
+  num_repetitions: 3
   # (question, condition, repetition) triples are evaluated concurrently up to
   # this limit. Higher values reduce wall-clock time but increase API load.
   # Values up to 50 seem to be well-tolerated on Vertex AI in practice.
@@ -94,23 +94,27 @@ execution:
     backoff_multiplier: 2 # backoff doubles on each retry: 1s, 2s, 4s, ...
 ```
 
+## CLI Options
+
+(Must be run from the src/ directory)
+
+```
+uv run python -m cli.main [OPTIONS] CONFIG_PATH
+
+  --output-dir, -o PATH   Directory for output files [default: ./results]
+  --log-format TEXT        Log format: 'console' or 'json' [default: console]
+  --quiet, -q              Suppress debug and info logs; show only the progress bar plus warnings/errors.
+```
+
+Use `--log-format json` when piping output to another tool. The Rich progress bars are suppressed automatically in this mode to keep stdout clean.
+
 ## Inference Provider Authentication
 
-As a general rule, `k-eval` relies on the user's environment
-to provide authentication details required to run the agent and
-llm judge as configured in the evaluation configuration file.
-
-The required environment variables will differ depending on the agent
-used, and are likely to differ slightly between the agent and judge.
-
-For now, we will focus on providing instructions for running Claude Agent SDK
-using Vertex AI, and running judge models hosted on Vertex AI.
-
+`k-eval` reads credentials from your environment. The required variables depend on which agent and judge providers you configure. Below are instructions for the currently supported combination: Claude Code SDK on Vertex AI as the agent, and a Vertex AI model via LiteLLM as the judge.
 
 ### Agent
 
-All [environment variables required to run the Claude Agent SDK](https://code.claude.com/docs/en/google-vertex-ai)
-must be present in the user's environment:
+See the [Claude Code SDK docs](https://code.claude.com/docs/en/google-vertex-ai) for the full reference.
 
 ```bash
 # Enable Vertex AI integration
@@ -127,14 +131,10 @@ export VERTEX_REGION_CLAUDE_3_5_HAIKU=us-east5
 
 ### Judge
 
-All [environment variables required to use Vertex AI models with LiteLLM](https://docs.litellm.ai/docs/providers/vertex#environment-variables)
-must be present in the user's environment. 
-
-Note that LiteLLM's environment variable names may differ slightly compared
-to those used to configure agent authentication.
+See the [LiteLLM Vertex AI docs](https://docs.litellm.ai/docs/providers/vertex#environment-variables) for the full reference.
 
 ```bash
 export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service_account.json"
-export VERTEXAI_LOCATION="us-central1" # can be any vertex location
-export VERTEXAI_PROJECT="my-test-project" # ONLY use if model project is different from service account project
+export VERTEXAI_LOCATION="us-central1"          # can be any Vertex AI region
+export VERTEXAI_PROJECT="my-test-project"        # only needed if different from your service account project
 ```


### PR DESCRIPTION
## Summary

Adds minimal instructions for getting started with `k-eval`.
