### PR TITLE
fix: cleanup diagnostic infrastructure and sync uv.lock on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,18 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - name: Sync uv.lock on release PR
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          gh pr checkout "${{ fromJson(steps.release.outputs.pr).number }}"
+          cd src/k-eval
+          uvx uv lock
+          git add uv.lock
+          git commit -m "chore: sync uv.lock with version bump" || echo "No changes to commit"
+          git push
+
       - name: Enable auto-merge on Release PR
         if: ${{ steps.release.outputs.pr }}
         env:

--- a/src/k-eval/k_eval/agent/infrastructure/claude_sdk.py
+++ b/src/k-eval/k_eval/agent/infrastructure/claude_sdk.py
@@ -1,7 +1,5 @@
 """ClaudeAgentSDKAgent — agent implementation using the Claude Agent SDK."""
 
-import asyncio
-import json
 import os
 import time
 from dataclasses import dataclass
@@ -33,30 +31,6 @@ from k_eval.agent.infrastructure.errors import AgentInvocationError
 from k_eval.config.domain.agent import AgentConfig
 from k_eval.config.domain.condition_mcp_server import ConditionMcpServer
 from k_eval.config.domain.mcp_server import HttpMcpServer, SseMcpServer, StdioMcpServer
-
-
-def _format_invocation_trace(
-    prompt: str,
-    turns: list[AgentTurn],
-    result_message: ResultMessage | None,
-) -> str:
-    """Format user_message + assistant/tool turns + final result for failure diagnostics."""
-    parts: list[str] = ["--- user_message ---", prompt or "(empty)"]
-    for turn in turns:
-        if turn.role == "assistant":
-            parts.append(f"\n--- ASSISTANT (turn {turn.turn_idx}) ---")
-            parts.append(turn.text or "(no text)")
-        else:
-            parts.append(f"\n--- TOOL_USE (turn {turn.turn_idx}) ---")
-            for tc in turn.tool_calls:
-                parts.append(f"  {tc.tool_name}: input={tc.tool_input!r}")
-                parts.append(f"    result={tc.tool_result!r} error={tc.tool_error}")
-    parts.append("\n--- FINAL_RESULT ---")
-    if result_message is not None and result_message.result is not None:
-        parts.append(result_message.result)
-    else:
-        parts.append("(none)")
-    return "\n".join(parts)
 
 
 @dataclass(frozen=True)
@@ -210,48 +184,6 @@ class ClaudeAgentSDKAgent:
                 if stderr_lines
                 else base_reason
             )
-            exc_result_message: ResultMessage | None = getattr(
-                exc, "result_message", None
-            )
-            exc_prompt = getattr(exc, "prompt", None) or ""
-            exc_turns = getattr(exc, "turns", None) or []
-            invocation_trace = _format_invocation_trace(
-                prompt=exc_prompt, turns=exc_turns, result_message=exc_result_message
-            )
-            exc.invocation_trace = invocation_trace  # type: ignore[attr-defined]
-            self._log.error(
-                "agent.invocation_trace",
-                condition=self._condition,
-                sample_idx=self._sample_idx,
-                full_trace=invocation_trace,
-            )
-            if exc_result_message is not None:
-                result_preview = (exc_result_message.result or "")[:500] + (
-                    "..." if len(exc_result_message.result or "") > 500 else ""
-                )
-                self._log.info(
-                    "agent.result_message_before_failure",
-                    condition=self._condition,
-                    sample_idx=self._sample_idx,
-                    is_error=exc_result_message.is_error,
-                    result_preview=result_preview,
-                    duration_ms=getattr(exc_result_message, "duration_ms", None),
-                    num_turns=getattr(exc_result_message, "num_turns", None),
-                )
-            else:
-                self._log.info(
-                    "agent.result_message_before_failure",
-                    condition=self._condition,
-                    sample_idx=self._sample_idx,
-                    result_message=None,
-                )
-            diagnostic = await self._run_diagnostic(options=options)
-            self._log.error(
-                "agent.subprocess.diagnostic",
-                condition=self._condition,
-                sample_idx=self._sample_idx,
-                result=diagnostic,
-            )
             self._observer.agent_invocation_failed(
                 condition=self._condition,
                 sample_idx=self._sample_idx,
@@ -277,100 +209,6 @@ class ClaudeAgentSDKAgent:
             usage=self._map_usage(raw=result_message.usage),
             turns=turns,
         )
-
-    async def _run_diagnostic(self, options: ClaudeAgentOptions) -> str:
-        """Spawn the claude CLI directly to capture its actual stdout and stderr.
-
-        The SDK's callback-based stderr capture races with task-group cleanup and
-        reliably loses data for fast-failing processes.  Running the subprocess
-        ourselves with asyncio.create_subprocess_exec and awaiting communicate()
-        guarantees that all output is collected before we return.
-        """
-        try:
-            from claude_agent_sdk._internal.transport.subprocess_cli import (  # noqa: PLC0415
-                SubprocessCLITransport,
-            )
-
-            transport = SubprocessCLITransport(prompt="", options=options)
-            cmd = transport._build_command()
-
-            ping_msg = (
-                json.dumps(
-                    {
-                        "type": "user",
-                        "session_id": "",
-                        "message": {"role": "user", "content": "ping"},
-                        "parent_tool_use_id": None,
-                    }
-                )
-                + "\n"
-            )
-
-            proc_env = {
-                **os.environ,
-                **options.env,
-                "CLAUDE_CODE_ENTRYPOINT": "sdk-py",
-            }
-
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=proc_env,
-            )
-            try:
-                stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                    proc.communicate(ping_msg.encode()),
-                    timeout=10.0,
-                )
-            except TimeoutError:
-                proc.kill()
-                return "diagnostic: timed out after 10s (process may be healthy)"
-
-            stdout_text = stdout_bytes.decode(errors="replace").strip()
-            stderr_text = stderr_bytes.decode(errors="replace").strip()
-
-            mcp_status = self._extract_mcp_status(stdout_text)
-
-            return (
-                f"rc={proc.returncode} | "
-                f"mcp_servers={mcp_status} | "
-                f"stderr={stderr_text[:2000]!r} | "
-                f"stdout={stdout_text[:2000]!r}"
-            )
-        except Exception as exc:
-            return f"diagnostic: could not run subprocess: {exc}"
-
-    def _extract_mcp_status(self, stdout_text: str) -> str:
-        """Parse the claude CLI's init JSON from stdout and extract MCP server statuses.
-
-        The init message is the first JSON object on stdout. It contains a
-        ``mcp_servers`` list with ``name``, ``status``, and an optional
-        ``error`` field for each server.  We surface that directly so the
-        diagnostic log line is immediately actionable without reading truncated
-        raw stdout.
-        """
-        for line in stdout_text.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                msg = json.loads(line)
-            except (json.JSONDecodeError, ValueError):
-                continue
-            if msg.get("type") == "system" and msg.get("subtype") == "init":
-                servers = msg.get("mcp_servers", [])
-                if not servers:
-                    return "none"
-                parts = []
-                for s in servers:
-                    name = s.get("name", "?")
-                    status = s.get("status", "?")
-                    error = s.get("error") or s.get("error_message") or ""
-                    parts.append(f"{name}:{status}" + (f"({error})" if error else ""))
-                return ", ".join(parts)
-        return "init message not found"
 
     async def _collect_result(
         self, prompt: str, options: ClaudeAgentOptions
@@ -486,7 +324,7 @@ class ClaudeAgentSDKAgent:
                         )
                         turn_idx += 1
 
-        except ClaudeSDKError as exc:
+        except (ClaudeSDKError, Exception) as exc:
             # If we already have a valid final result, return it instead of failing.
             # The stream may have died (e.g. MCP timeout) after sending ResultMessage.
             if (
@@ -501,31 +339,13 @@ class ClaudeAgentSDKAgent:
                     error=str(exc),
                 )
             else:
-                err = AgentInvocationError(reason=str(exc), retriable=True)
-                err.result_message = result_message  # type: ignore[attr-defined]
-                err.prompt = prompt  # type: ignore[attr-defined]
-                err.turns = list(turns)  # type: ignore[attr-defined]
-                raise err from exc
-        except Exception as exc:
-            # The SDK internally raises a bare Exception (not ClaudeSDKError) when
-            # its message reader encounters a fatal error (e.g. subprocess exit).
-            if (
-                result_message is not None
-                and not result_message.is_error
-                and result_message.result is not None
-            ):
-                self._log.warning(
-                    "agent.stream_error_after_result",
-                    condition=self._condition,
-                    sample_idx=self._sample_idx,
-                    error=str(exc),
-                )
-            else:
-                err = AgentInvocationError(reason=str(exc), retriable=True)
-                err.result_message = result_message  # type: ignore[attr-defined]
-                err.prompt = prompt  # type: ignore[attr-defined]
-                err.turns = list(turns)  # type: ignore[attr-defined]
-                raise err from exc
+                raise AgentInvocationError(
+                    reason=str(exc),
+                    retriable=True,
+                    result_message=result_message,
+                    prompt=prompt,
+                    turns=list(turns),
+                ) from exc
 
         # Emit any pending tool calls that were never resolved (duration_ms=None).
         if pending_tool_calls:
@@ -550,27 +370,28 @@ class ClaudeAgentSDKAgent:
             )
 
         if result_message is None:
-            err = AgentInvocationError(reason="no ResultMessage in response stream")
-            err.result_message = None  # type: ignore[attr-defined]
-            err.prompt = prompt  # type: ignore[attr-defined]
-            err.turns = list(turns)  # type: ignore[attr-defined]
-            raise err
+            raise AgentInvocationError(
+                reason="no ResultMessage in response stream",
+                result_message=None,
+                prompt=prompt,
+                turns=list(turns),
+            )
 
         if result_message.is_error:
-            err = AgentInvocationError(
-                reason=f"agent returned error response: {result_message.result}"
+            raise AgentInvocationError(
+                reason=f"agent returned error response: {result_message.result}",
+                result_message=result_message,
+                prompt=prompt,
+                turns=list(turns),
             )
-            err.result_message = result_message  # type: ignore[attr-defined]
-            err.prompt = prompt  # type: ignore[attr-defined]
-            err.turns = list(turns)  # type: ignore[attr-defined]
-            raise err
 
         if result_message.result is None:
-            err = AgentInvocationError(reason="ResultMessage has no result text")
-            err.result_message = result_message  # type: ignore[attr-defined]
-            err.prompt = prompt  # type: ignore[attr-defined]
-            err.turns = list(turns)  # type: ignore[attr-defined]
-            raise err
+            raise AgentInvocationError(
+                reason="ResultMessage has no result text",
+                result_message=result_message,
+                prompt=prompt,
+                turns=list(turns),
+            )
 
         return result_message, turns
 

--- a/src/k-eval/k_eval/agent/infrastructure/errors.py
+++ b/src/k-eval/k_eval/agent/infrastructure/errors.py
@@ -1,13 +1,35 @@
 """Error types raised by agent infrastructure."""
 
+from typing import TYPE_CHECKING, Any
+
 from k_eval.core.errors import KEvalError
+
+if TYPE_CHECKING:
+    from k_eval.agent.domain.turn import AgentTurn
 
 
 class AgentInvocationError(KEvalError):
-    """Raised when the agent cannot be invoked or returns an error response."""
+    """Raised when the agent cannot be invoked or returns an error response.
 
-    def __init__(self, reason: str, retriable: bool = False) -> None:
+    Attributes:
+        result_message: The ResultMessage from the SDK, if available before failure.
+        prompt: The user prompt that was sent to the agent.
+        turns: The conversation turns collected before the error occurred.
+    """
+
+    def __init__(
+        self,
+        reason: str,
+        retriable: bool = False,
+        *,
+        result_message: Any | None = None,
+        prompt: str = "",
+        turns: list["AgentTurn"] | None = None,
+    ) -> None:
         super().__init__(f"Failed to invoke agent: {reason}", retriable=retriable)
+        self.result_message = result_message
+        self.prompt = prompt
+        self.turns = turns if turns is not None else []
 
 
 class AgentTypeNotSupportedError(KEvalError):

--- a/src/k-eval/k_eval/judge/infrastructure/litellm.py
+++ b/src/k-eval/k_eval/judge/infrastructure/litellm.py
@@ -6,7 +6,6 @@ import time
 
 import litellm
 import openai
-import structlog
 from pydantic import ValidationError
 
 from k_eval.config.domain.judge import JudgeConfig
@@ -144,18 +143,6 @@ class LiteLLMJudge:
             condition=self._condition,
             sample_idx=self._sample_idx,
             model=self._config.model,
-        )
-
-        _log = structlog.get_logger()
-        _log.debug(
-            "judge.env_proxy_and_base",
-            condition=self._condition,
-            sample_idx=self._sample_idx,
-            HTTP_PROXY=os.environ.get("HTTP_PROXY", ""),
-            HTTPS_PROXY=os.environ.get("HTTPS_PROXY", ""),
-            http_proxy=os.environ.get("http_proxy", ""),
-            https_proxy=os.environ.get("https_proxy", ""),
-            LITELLM_API_BASE=os.environ.get("LITELLM_API_BASE", ""),
         )
 
         # Clear proxy env vars that may have been polluted by the claude-agent-sdk.

--- a/src/k-eval/pyproject.toml
+++ b/src/k-eval/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
     "claude-agent-sdk>=0.1.65",
-    "litellm",
+    "litellm==1.81.14",
     "pydantic>=2.12.5",
     "pyyaml>=6.0.3",
     "rich>=14.3.3",

--- a/src/k-eval/uv.lock
+++ b/src/k-eval/uv.lock
@@ -934,7 +934,7 @@ wheels = [
 
 [[package]]
 name = "k-eval"
-version = "1.1.2"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },


### PR DESCRIPTION
## Summary
- Remove `_format_invocation_trace`, `_run_diagnostic`, and `_extract_mcp_status` methods that used private SDK APIs (`claude_agent_sdk._internal`)
- Add proper `result_message`, `prompt`, and `turns` fields to `AgentInvocationError` instead of monkey-patching
- Consolidate duplicate exception handlers into single `except (ClaudeSDKError, Exception)`
- Re-pin `litellm==1.81.14` (was accidentally unpinned)
- Add workflow step to sync `uv.lock` when release-please bumps version
- Remove noisy debug log message from judge