### PR TITLE
fix: add checkout step before uv.lock sync in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,10 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - name: Checkout for uv.lock sync
+        if: ${{ steps.release.outputs.pr }}
+        uses: actions/checkout@v4
+
       - name: Sync uv.lock on release PR
         if: ${{ steps.release.outputs.pr }}
         env:

--- a/src/k-eval/k_eval/cli/main.py
+++ b/src/k-eval/k_eval/cli/main.py
@@ -418,6 +418,18 @@ def _print_summary(
     typer.echo("")
 
 
+def _clear_proxy_env_vars() -> None:
+    """Clear proxy env vars that may interfere with Google OAuth.
+
+    The claude-agent-sdk sets HTTP_PROXY/HTTPS_PROXY pointing to a local auth
+    proxy. If these leak into the parent process's os.environ, litellm's Vertex
+    AI credential refresh will try to route through the (now dead) proxy and
+    fail. Clearing them once at startup avoids per-call race conditions.
+    """
+    for key in ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"]:
+        os.environ.pop(key, None)
+
+
 @app.command()
 def run(
     config_path: Path = typer.Argument(..., help="Path to evaluation config YAML"),
@@ -440,17 +452,6 @@ def run(
     ),
 ) -> None:
     """Run a k-eval evaluation from a YAML config file."""
-    def _clear_proxy_env_vars() -> None:
-        """
-        Clear proxy env vars that may interfere with Google OAuth.
-        The claude-agent-sdk sets HTTP_PROXY/HTTPS_PROXY pointing to a local auth
-        proxy. If these leak into the parent process's os.environ, litellm's Vertex
-        AI credential refresh will try to route through the (now dead) proxy and
-        fail. Clearing them once at startup avoids per-call race conditions.
-        """
-        for key in ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"]:
-            os.environ.pop(key, None)
-    
     try:
         _clear_proxy_env_vars()
         _configure_structlog(log_format=log_format, quiet=quiet)

--- a/src/k-eval/k_eval/cli/main.py
+++ b/src/k-eval/k_eval/cli/main.py
@@ -440,9 +440,20 @@ def run(
     ),
 ) -> None:
     """Run a k-eval evaluation from a YAML config file."""
+    def _clear_proxy_env_vars() -> None:
+        """
+        Clear proxy env vars that may interfere with Google OAuth.
+        The claude-agent-sdk sets HTTP_PROXY/HTTPS_PROXY pointing to a local auth
+        proxy. If these leak into the parent process's os.environ, litellm's Vertex
+        AI credential refresh will try to route through the (now dead) proxy and
+        fail. Clearing them once at startup avoids per-call race conditions.
+        """
+        for key in ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"]:
+            os.environ.pop(key, None)
+    
     try:
+        _clear_proxy_env_vars()
         _configure_structlog(log_format=log_format, quiet=quiet)
-
         config_observer = StructlogConfigObserver()
         loader = YamlConfigLoader(observer=config_observer)
         try:

--- a/src/k-eval/k_eval/judge/infrastructure/litellm.py
+++ b/src/k-eval/k_eval/judge/infrastructure/litellm.py
@@ -1,7 +1,6 @@
 """LiteLLMJudge — judge implementation using LiteLLM for structured scoring."""
 
 import json
-import os
 import time
 
 import litellm
@@ -145,25 +144,6 @@ class LiteLLMJudge:
             model=self._config.model,
         )
 
-        # Clear proxy env vars that may have been polluted by the claude-agent-sdk.
-        # The SDK sets up a local auth proxy that leaks into os.environ and breaks
-        # litellm's Vertex AI credential refresh via Google OAuth.
-        proxy_keys = [
-            "HTTP_PROXY",
-            "HTTPS_PROXY",
-            "http_proxy",
-            "https_proxy",
-            "NO_PROXY",
-            "no_proxy",
-        ]
-        saved_proxies = {k: os.environ.get(k) for k in proxy_keys}
-
-        # Remove existing proxy settings and set NO_PROXY to bypass for Google APIs
-        for k in ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"]:
-            os.environ.pop(k, None)
-        os.environ["NO_PROXY"] = "oauth2.googleapis.com,googleapis.com,*.googleapis.com"
-        os.environ["no_proxy"] = "oauth2.googleapis.com,googleapis.com,*.googleapis.com"
-
         user_message = (
             f"## Question\n{question}\n\n"
             f"## Golden Answer\n{golden_answer}\n\n"
@@ -172,44 +152,36 @@ class LiteLLMJudge:
 
         start = time.monotonic()
         try:
-            try:
-                response = await litellm.acompletion(
-                    model=self._config.model,
-                    temperature=self._config.temperature,
-                    response_format=JudgeResult,
-                    messages=[
-                        {"role": "system", "content": _SYSTEM_PROMPT},
-                        {"role": "user", "content": user_message},
-                    ],
-                )
-            except openai.APIError as exc:
-                # openai.APIError is the common base class for all litellm API errors.
-                # InternalServerError is included because LiteLLM raises it for transient
-                # upstream failures (e.g. a 502 from the Google OAuth2 token endpoint during
-                # credential refresh) that are unrelated to the model call itself.
-                retriable = isinstance(
-                    exc,
-                    (
-                        openai.RateLimitError,
-                        openai.APIConnectionError,
-                        openai.APITimeoutError,
-                        openai.InternalServerError,
-                    ),
-                )
-                reason = str(exc)
-                self._observer.judge_scoring_failed(
-                    condition=self._condition,
-                    sample_idx=self._sample_idx,
-                    reason=reason,
-                )
-                raise JudgeInvocationError(reason=reason, retriable=retriable) from exc
-        finally:
-            # Restore proxy env vars in case other code depends on them.
-            for key, value in saved_proxies.items():
-                if value is not None:
-                    os.environ[key] = value
-                else:
-                    os.environ.pop(key, None)
+            response = await litellm.acompletion(
+                model=self._config.model,
+                temperature=self._config.temperature,
+                response_format=JudgeResult,
+                messages=[
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "user", "content": user_message},
+                ],
+            )
+        except openai.APIError as exc:
+            # openai.APIError is the common base class for all litellm API errors.
+            # InternalServerError is included because LiteLLM raises it for transient
+            # upstream failures (e.g. a 502 from the Google OAuth2 token endpoint during
+            # credential refresh) that are unrelated to the model call itself.
+            retriable = isinstance(
+                exc,
+                (
+                    openai.RateLimitError,
+                    openai.APIConnectionError,
+                    openai.APITimeoutError,
+                    openai.InternalServerError,
+                ),
+            )
+            reason = str(exc)
+            self._observer.judge_scoring_failed(
+                condition=self._condition,
+                sample_idx=self._sample_idx,
+                reason=reason,
+            )
+            raise JudgeInvocationError(reason=reason, retriable=retriable) from exc
 
         duration_ms = int((time.monotonic() - start) * 1000)
 


### PR DESCRIPTION
## Summary

- **Fix release-please workflow**: Add checkout step before uv.lock sync (was failing with "not a git repository")
- **Simplify proxy workaround**: Move proxy clearing from per-call (with racy save/restore) to once at CLI startup
  - The claude-agent-sdk leaks `HTTP_PROXY`/`HTTPS_PROXY` into `os.environ`, breaking litellm's Vertex AI OAuth
  - Old approach: save/restore per judge call (had race conditions with concurrent tasks)
  - New approach: clear once at startup (simple, no races)