### PR TITLE
fix: add setup-uv step to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,6 +25,10 @@ jobs:
         if: ${{ steps.release.outputs.pr }}
         uses: actions/checkout@v4
 
+      - name: Set up uv
+        if: ${{ steps.release.outputs.pr }}
+        uses: astral-sh/setup-uv@v5
+
       - name: Sync uv.lock on release PR
         if: ${{ steps.release.outputs.pr }}
         env:


### PR DESCRIPTION
## Summary
- Add `astral-sh/setup-uv@v5` step to install uv before running `uvx uv lock`
- Fixes the `uvx: command not found` error in the release workflow

## Test plan
- Merge this PR and verify the release-please workflow succeeds
- PR #37 should then get its `uv.lock` synced and auto-merge


Made with [Cursor](https://cursor.com)