### PR TITLE
ci: add workflow_dispatch trigger to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to release-please workflow
- Allows manual triggering when needed (e.g., after closing a release PR)

## Test plan
- Merge this PR
- release-please will run and recreate the 1.2.1 release PR


Made with [Cursor](https://cursor.com)