### PR TITLE
chore: increment uv.lock k-eval version on each release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,9 +22,13 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      - name: Checkout for uv.lock sync
+      - name: Checkout release PR branch
         if: ${{ steps.release.outputs.pr }}
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          ref: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
+          fetch-depth: 0
 
       - name: Set up uv
         if: ${{ steps.release.outputs.pr }}
@@ -35,12 +39,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
-          gh pr checkout "${{ fromJson(steps.release.outputs.pr).number }}"
           cd src/k-eval
-          uvx uv lock
-          git add uv.lock
-          git commit -m "chore: sync uv.lock with version bump" || echo "No changes to commit"
-          git push
+          uv lock
+          if git diff --quiet uv.lock; then
+            echo "uv.lock is already up to date"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add uv.lock
+            git commit -m "chore: sync uv.lock with version bump"
+            git push
+          fi
 
       - name: Enable auto-merge on Release PR
         if: ${{ steps.release.outputs.pr }}

--- a/src/k-eval/k_eval/judge/infrastructure/litellm.py
+++ b/src/k-eval/k_eval/judge/infrastructure/litellm.py
@@ -8,21 +8,21 @@ import litellm
 import openai
 from pydantic import ValidationError
 
+from k_eval.config.domain.judge import JudgeConfig
+from k_eval.judge.domain.observer import JudgeObserver
+from k_eval.judge.domain.score import JudgeResult
+from k_eval.judge.infrastructure.errors import JudgeInvocationError
+
 # Suppress Pydantic serialization warnings from LiteLLM internals.
 # LiteLLM's response models (Message, StreamingChoices) sometimes have schema mismatches
 # when responses come from different providers (e.g., Vertex AI). The warning is benign
 # and the serialization still succeeds.
 warnings.filterwarnings(
-    "ignore",
+    action="ignore",
     message=r"Pydantic serializer warnings:",
     category=UserWarning,
     module=r"pydantic\.main",
 )
-
-from k_eval.config.domain.judge import JudgeConfig
-from k_eval.judge.domain.observer import JudgeObserver
-from k_eval.judge.domain.score import JudgeResult
-from k_eval.judge.infrastructure.errors import JudgeInvocationError
 
 _SYSTEM_PROMPT = """\
 You are an expert evaluator assessing the quality of AI agent responses against \

--- a/src/k-eval/k_eval/judge/infrastructure/litellm.py
+++ b/src/k-eval/k_eval/judge/infrastructure/litellm.py
@@ -2,10 +2,22 @@
 
 import json
 import time
+import warnings
 
 import litellm
 import openai
 from pydantic import ValidationError
+
+# Suppress Pydantic serialization warnings from LiteLLM internals.
+# LiteLLM's response models (Message, StreamingChoices) sometimes have schema mismatches
+# when responses come from different providers (e.g., Vertex AI). The warning is benign
+# and the serialization still succeeds.
+warnings.filterwarnings(
+    "ignore",
+    message=r"Pydantic serializer warnings:",
+    category=UserWarning,
+    module=r"pydantic\.main",
+)
 
 from k_eval.config.domain.judge import JudgeConfig
 from k_eval.judge.domain.observer import JudgeObserver

--- a/src/k-eval/uv.lock
+++ b/src/k-eval/uv.lock
@@ -934,7 +934,7 @@ wheels = [
 
 [[package]]
 name = "k-eval"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },


### PR DESCRIPTION
increment uv.lock's k-eval version on each release + supress warning

---

Opened from local commit; branch `chore/uv-lock-on-release-please`.

Made with [Cursor](https://cursor.com)